### PR TITLE
Add if statement to check if removed snippet is currently being edited

### DIFF
--- a/src/renderer/windows/main/components/Snippets.vue
+++ b/src/renderer/windows/main/components/Snippets.vue
@@ -320,7 +320,9 @@
             },
             remove(snippet) {
                 this.snippets = this.snippets.filter(s => s.id !== snippet.id)
-                this.editing = null
+                if (this.editing === snippet) {
+                    this.editing = null
+                }
             },
             save() {
                 this.statusVisible = true


### PR DESCRIPTION
Fixes #47. The if statement checks it the removed snippet is currently being edited. If it is, then and only then will it close the editor.