### PR TITLE
Add CSS to truncate long snippet keys

### DIFF
--- a/src/renderer/styles/app.sass
+++ b/src/renderer/styles/app.sass
@@ -85,6 +85,9 @@ select, button
 .-ml-64
     margin-left: -4rem
 
+.max-w-42
+    max-width: 42%
+
 .center-y
     top: 50%
     transform: translateY(-50%)

--- a/src/renderer/windows/main/components/Snippets.vue
+++ b/src/renderer/windows/main/components/Snippets.vue
@@ -1,6 +1,6 @@
 <template>
     <div class="bg flex h-screen font-sans" :class="['bg-black text-grey-light', 'bg-image text-grey-darkest'][theme]" id="app">
-        <div class="flex flex-col flex-2 p-8">
+        <div class="flex flex-col flex-2 p-8 max-w-42">
             <h1 class="flex items-center h-12">
                 <span class="flex-1">
                     <span class="text-3xl">Snippets</span>
@@ -37,7 +37,7 @@
                     @keydown.space="edit(snippet)"
                     @click="edit(snippet)"
                 >
-                    <span class="flex-1">{{ snippet.key }}</span>
+                    <span class="flex-1 truncate">{{ snippet.key }}</span>
                     <span
                         class="px-3 ml-2 text-grey-darkest py-1 text-xs bg-grey rounded-full"
                         v-if="snippet.regex"


### PR DESCRIPTION
Fixes #43. I used Tailwind's built-in `.truncate` class to truncate the actual text, but this would not work without a width set on the left column. I opted for `max-width` so the column could still flex appropriately. I created a `max-w-42` class to set `max-width: 42%` as the existing Tailwind `max-w-` classes did not provide percentage-based options and 42% approximated the column's current flexibility. Let me know if you think this should be changed in any way.

![image](https://user-images.githubusercontent.com/4968754/46643647-f304da00-cb4a-11e8-92f8-f7f8cf02b11b.png)
