### PR TITLE
Add github actions workflow on push

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on: [push]
+
+jobs:
+  test-compile:
+    name: build and publish
+    runs-on: macOS-latest
+    strategy:
+      matrix:
+        node-version: [8.x]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Use Node Version ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: install, test, build
+        run: |
+          npm install
+          npm run prod
+          npm run dist
+          npm run test
+          echo 'Done!'


### PR DESCRIPTION
#60 

Added the github actions workflow. This workflow is almost similar to the travis workflow. Right now, the workflow gets triggered on every push to any branch but it can be configured as required.  